### PR TITLE
skip the DocLint done by Java 8 automatically

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,9 @@
                     <goals>
                       <goal>jar</goal>
                     </goals>
+                    <configuration>
+                        <additionalparam>-Xdoclint:none</additionalparam>
+                    </configuration>
                 </execution>
             </executions>
         </plugin>


### PR DESCRIPTION
Java 8 has a new feature called DocLint. If comment tags are incomplete, the DocLint will break the compilation. This flag will just skip doing DocLint.