### PR TITLE
The -Xdoclint:none flag breaks Java < 1.8 versions. Fixed with a prof…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,18 @@
 	<mockito.version>1.8.5</mockito.version>
   </properties>
 
+  <profiles>
+    <profile>
+      <id>doclint-java8-disable</id>
+      <activation>
+        <jdk>[1.8,)</jdk>
+      </activation>
+      <properties>
+        <javadoc.opts>-Xdoclint:none</javadoc.opts>
+      </properties>
+    </profile>
+  </profiles>
+
   <dependencies>
   	<dependency>
 			<groupId>org.mockito</groupId>
@@ -69,7 +81,7 @@
                       <goal>jar</goal>
                     </goals>
                     <configuration>
-                        <additionalparam>-Xdoclint:none</additionalparam>
+                        <additionalparam>${javadoc.opts}</additionalparam>
                     </configuration>
                 </execution>
             </executions>


### PR DESCRIPTION
Seems like the previous change was breaking java versions < 1.8. This is using a profile for Java 1.8 +. I've tested with Java 1.7 and 1.8.